### PR TITLE
CDI-1536 Add Zun container endpoints

### DIFF
--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -1,0 +1,8 @@
+FROM php:8.1-alpine
+
+COPY --from=composer:latest /usr/bin/composer /usr/local/bin/composer
+
+RUN apk add --no-cache --update git linux-headers $PHPIZE_DEPS \
+    && pecl install xdebug \
+    && docker-php-ext-enable xdebug \
+    && apk del $PHPIZE_DEPS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,12 @@ do not know how to do this, please follow [these instructions](https://help.gith
 composer install
 ```
 
+Or using Docker Compose:
+
+```bash
+docker compose run -it --rm php sh -c "composer install"
+```
+
 5. Once everything is installed, you're ready to go! If you are working on a new feature, check out a new
 feature brach:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  php:
+    working_dir: /var/www/html
+    build: .docker/php
+    volumes:
+      - .:/var/www/html

--- a/src/Common/Api/AbstractApi.php
+++ b/src/Common/Api/AbstractApi.php
@@ -6,7 +6,7 @@ namespace OpenStack\Common\Api;
 
 abstract class AbstractApi implements ApiInterface
 {
-    protected $params;
+    protected AbstractParams $params;
 
     protected function isRequired(array $param): array
     {

--- a/src/Common/Api/AbstractParams.php
+++ b/src/Common/Api/AbstractParams.php
@@ -21,6 +21,7 @@ abstract class AbstractParams
     public const ARRAY_TYPE   = 'array';
     public const NULL_TYPE    = 'NULL';
     public const INT_TYPE     = 'integer';
+    public const FLOAT_TYPE   = 'double';
     public const INTEGER_TYPE = self::INT_TYPE;
 
     public static function isSupportedLocation(string $val): bool

--- a/src/Common/Resource/Iterator.php
+++ b/src/Common/Resource/Iterator.php
@@ -16,6 +16,7 @@ class Iterator
     private $markerKey;
     private $mapFn;
     private $currentMarker;
+    private $sentMarkers = [];
 
     public function __construct(array $options, callable $requestFn, callable $resourceFn)
     {
@@ -42,6 +43,10 @@ class Iterator
     {
         if ($this->shouldNotSendAnotherRequest()) {
             return false;
+        }
+
+        if ($this->currentMarker) {
+            $this->sentMarkers[] = $this->currentMarker;
         }
 
         $response = call_user_func($this->requestFn, $this->currentMarker);
@@ -74,12 +79,19 @@ class Iterator
 
     private function totalReached()
     {
-        return $this->limit && $this->count >= $this->limit;
+        return ($this->limit && $this->count >= $this->limit) || $this->markerSent();
     }
 
     private function shouldNotSendAnotherRequest()
     {
-        return $this->totalReached() || ($this->count > 0 && !$this->markerKey);
+        return $this->totalReached()
+            || ($this->count > 0 && !$this->markerKey)
+            || $this->markerSent();
+    }
+
+    private function markerSent()
+    {
+        return $this->currentMarker && in_array($this->currentMarker, $this->sentMarkers);
     }
 
     public function __invoke()

--- a/src/Containers/v1/Api.php
+++ b/src/Containers/v1/Api.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenStack\Containers\v1;
+
+use OpenStack\Common\Api\AbstractApi;
+
+/**
+ * A representation of the Containers Zun v1 REST API.
+ *
+ * @internal
+ */
+class Api extends AbstractApi
+{
+    public function __construct()
+    {
+        $this->params = new Params();
+    }
+
+    public function create(): array
+    {
+        return [
+            'method' => 'POST',
+            'path'   => 'containers',
+            'params' => $this->params->container(),
+        ];
+    }
+
+    public function list(): array
+    {
+        return [
+            'method' => 'GET',
+            'path'   => 'containers',
+            'params' => [
+                'name'       => $this->params->name(),
+                'image'      => $this->params->image(),
+                'projectId'  => $this->params->projectId(),
+                'userId'     => $this->params->userId(),
+                'memory'     => $this->params->memory(),
+                'host'       => $this->params->host(),
+                'taskState'  => $this->params->taskState(),
+                'status'     => $this->params->status(),
+                'autoRemove' => $this->params->autoRemove(),
+            ],
+        ];
+    }
+
+    public function details(): array
+    {
+        return [
+            'method' => 'GET',
+            'path'   => 'containers/{id}',
+            'params' => [
+                'id' => $this->params->idPath(),
+            ],
+        ];
+    }
+
+    public function delete(): array
+    {
+        return [
+            'method' => 'DELETE',
+            'path'   => 'containers/{id}',
+            'params' => [
+                'id' => $this->params->idPath(),
+            ],
+        ];
+    }
+
+    public function kill(): array
+    {
+        return [
+            'method' => 'POST',
+            'path'   => 'containers/{id}/kill',
+            'params' => [
+                'id'     => $this->params->idPath(),
+                'signal' => $this->params->signal(),
+            ],
+        ];
+    }
+
+    public function start(): array
+    {
+        return [
+            'method' => 'POST',
+            'path'   => 'containers/{id}/start',
+            'params' => [
+                'id' => $this->params->idPath(),
+            ],
+        ];
+    }
+
+    public function stop(): array
+    {
+        return [
+            'method' => 'POST',
+            'path'   => 'containers/{id}/stop',
+            'params' => [
+                'id' => $this->params->idPath(),
+            ],
+        ];
+    }
+
+    public function pause(): array
+    {
+        return [
+            'method' => 'POST',
+            'path'   => 'containers/{id}/pause',
+            'params' => [
+                'id' => $this->params->idPath(),
+            ],
+        ];
+    }
+
+    public function unpause(): array
+    {
+        return [
+            'method' => 'POST',
+            'path'   => 'containers/{id}/unpause',
+            'params' => [
+                'id' => $this->params->idPath(),
+            ],
+        ];
+    }
+
+    public function rebuild(): array
+    {
+        return [
+            'method' => 'POST',
+            'path'   => 'containers/{id}/rebuild',
+            'params' => [
+                'id' => $this->params->idPath(),
+            ],
+        ];
+    }
+
+    public function reboot(): array
+    {
+        return [
+            'method' => 'POST',
+            'path'   => 'containers/{id}/reboot',
+            'params' => [
+                'id' => $this->params->idPath(),
+            ],
+        ];
+    }
+
+    public function logs(): array
+    {
+        return [
+            'method' => 'GET',
+            'path'   => 'containers/{id}/logs',
+            'params' => [
+                'id'         => $this->params->idPath(),
+                'stdout'     => $this->params->stdout(),
+                'stderr'     => $this->params->stderr(),
+                'timestamps' => $this->params->timestamps(),
+                'tail'       => $this->params->tail(),
+                'since'      => $this->params->since(),
+            ],
+        ];
+    }
+
+    public function attach(): array
+    {
+        return [
+            'method' => 'GET',
+            'path'   => 'containers/{id}/attach',
+            'params' => [
+                'id' => $this->params->idPath(),
+            ],
+        ];
+    }
+
+    public function resize(): array
+    {
+        return [
+            'method' => 'POST',
+            'path'   => 'containers/{id}/resize',
+            'params' => [
+                'id'     => $this->params->idPath(),
+                'width'  => $this->params->ttyWidth(),
+                'height' => $this->params->ttyHeight(),
+            ],
+        ];
+    }
+
+    public function commit(): array
+    {
+        return [
+            'method' => 'POST',
+            'path'   => 'containers/{id}/commit',
+            'params' => [
+                'id'         => $this->params->idPath(),
+                'repository' => $this->params->repository(),
+                'tag'        => $this->params->tag(),
+            ],
+        ];
+    }
+}

--- a/src/Containers/v1/Enum.php
+++ b/src/Containers/v1/Enum.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OpenStack\Containers\v1;
+
+abstract class Enum
+{
+    private function __construct()
+    {
+    }
+
+    public const KIND_CAPSULE = 'capsule';
+
+    public const RESTART_POLICY_ALWAYS     = 'Always';
+    public const RESTART_POLICY_ON_FAILURE = 'OnFailure';
+    public const RESTART_POLICY_NEVER      = 'Never';
+
+    public const PORT_PROTOCOL_TCP = 'TCP';
+    public const PORT_PROTOCOL_UDP = 'UDP';
+
+    private function __clone()
+    {
+    }
+}

--- a/src/Containers/v1/Models/Container.php
+++ b/src/Containers/v1/Models/Container.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenStack\Containers\v1\Models;
+
+use OpenStack\Common\Resource\Creatable;
+use OpenStack\Common\Resource\Deletable;
+use OpenStack\Common\Resource\Listable;
+use OpenStack\Common\Resource\OperatorResource;
+use OpenStack\Common\Resource\Retrievable;
+use OpenStack\Containers\v1\Api;
+
+/**
+ * @property Api $api
+ */
+class Container extends OperatorResource implements Creatable, Listable, Retrievable, Deletable
+{
+    /** @var string */
+    public $id;
+
+    /** @var string */
+    public $uuid;
+
+    /** @var string */
+    public $name;
+
+    /** @var string */
+    public $image;
+
+    /** @var array */
+    public $links;
+
+    /** @var string */
+    public $status;
+
+    /** @var string */
+    public $taskState;
+
+    /** @var string */
+    public $userId;
+
+    /** @var string */
+    public $projectId;
+
+    /** @var string */
+    public $command;
+
+    /** @var float */
+    public $cpu;
+
+    /** @var string */
+    public $memory;
+
+    /** @var string */
+    public $environment;
+
+    /** @var string */
+    public $workdir;
+
+    /** @var bool */
+    public $interactive;
+
+    /** @var string */
+    public $imagePullPolicy;
+
+    /** @var array */
+    public $securityGroups;
+
+    /** @var bool */
+    public $autoRemove;
+
+    /** @var string */
+    public $runtime;
+
+    /** @var string */
+    public $hostname;
+
+    /** @var string */
+    public $cpuPolicy;
+
+    /** @var string */
+    public $statusReason;
+
+    /** @var array */
+    public $ports;
+
+    /** @var array */
+    public $labels;
+
+    /** @var array */
+    public $addresses;
+
+    /** @var array */
+    public $restartPolicy;
+
+    /** @var string */
+    public $statusDetail;
+
+    /** @var bool */
+    public $tty;
+
+    /** @var string */
+    public $imageDriver;
+
+    /** @var int */
+    public $disk;
+
+    /** @var bool */
+    public $autoHeal;
+
+    /** @var array */
+    public $healthcheck;
+
+    /** @var string */
+    public $registryId;
+
+    /** @var array */
+    public $entrypoint;
+
+    /** @var string */
+    public $createdAt;
+
+    /** @var string */
+    public $updatedAt;
+
+    protected $resourceKey  = 'container';
+    protected $resourcesKey = 'containers';
+    protected $markerKey    = 'uuid';
+
+    protected $aliases = [
+        'project_id'      => 'projectId',
+        'user_id'         => 'userId',
+        'cpu_policy'      => 'cpuPolicy',
+        'status_reason'   => 'statusReason',
+        'restart_policy'  => 'restartPolicy',
+        'status_detail'   => 'statusDetail',
+        'image_driver'    => 'imageDriver',
+        'auto_heal'       => 'autoHeal',
+        'registry_id'     => 'registryId',
+        'created_at'      => 'createdAt',
+        'updated_at'      => 'updatedAt',
+        'task_state'      => 'taskState',
+        'auto_remove'     => 'autoRemove',
+        'security_groups' => 'securityGroups',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function create(array $userOptions): self
+    {
+        $response = $this->execute($this->api->create(), $userOptions);
+
+        return $this->populateFromResponse($response);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function retrieve(): void
+    {
+        $response = $this->executeWithState($this->api->details());
+        $this->populateFromResponse($response);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function delete(): void
+    {
+        $this->executeWithState($this->api->delete());
+    }
+
+    public function start(): void
+    {
+        $this->executeWithState($this->api->start());
+    }
+
+    public function stop(): void
+    {
+        $this->executeWithState($this->api->stop());
+    }
+
+    public function reboot(): void
+    {
+        $this->executeWithState($this->api->reboot());
+    }
+
+    public function rebuild(): void
+    {
+        $this->executeWithState($this->api->rebuild());
+    }
+
+    public function pause(): void
+    {
+        $this->executeWithState($this->api->pause());
+    }
+
+    public function unpause(): void
+    {
+        $this->executeWithState($this->api->unpause());
+    }
+
+    public function kill(): void
+    {
+        $this->executeWithState($this->api->kill());
+    }
+
+    public function logs(array $options = []): string
+    {
+        $options['id'] = $this->id;
+        $response      = $this->execute($this->api->logs(), $options);
+
+        return (string) $response->getBody();
+    }
+
+    public function attach(): string
+    {
+        $response = $this->executeWithState($this->api->attach());
+
+        return (string) $response->getBody();
+    }
+
+    public function resize(array $options = []): void
+    {
+        $options['id'] = $this->id;
+        $this->execute($this->api->resize(), $options);
+    }
+
+    public function commit(array $options = []): ContainerImage
+    {
+        $options['id'] = $this->id;
+        $response      = $this->execute($this->api->commit(), $options);
+
+        return $this->model(ContainerImage::class)->populateFromResponse($response);
+    }
+}

--- a/src/Containers/v1/Models/ContainerImage.php
+++ b/src/Containers/v1/Models/ContainerImage.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenStack\Containers\v1\Models;
+
+use OpenStack\Common\Resource\OperatorResource;
+
+class ContainerImage extends OperatorResource
+{
+    /** @var string */
+    public $uuid;
+
+    protected $resourceKey  = 'containerImage';
+    protected $resourcesKey = 'containerImages';
+    protected $markerKey    = 'uuid';
+}

--- a/src/Containers/v1/Params.php
+++ b/src/Containers/v1/Params.php
@@ -1,0 +1,460 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenStack\Containers\v1;
+
+use OpenStack\Common\Api\AbstractParams;
+
+class Params extends AbstractParams
+{
+    public function container(): array
+    {
+        return [
+            'name' => [
+                'type'        => self::STRING_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'The name of the container.',
+            ],
+            'image' => [
+                'type'        => self::STRING_TYPE,
+                'location'    => self::JSON,
+                'required'    => true,
+                'description' => 'The name or ID of the image.',
+            ],
+            'command' => [
+                'type'        => self::STRING_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'Send command to the container.',
+            ],
+            'cpu' => [
+                'type'        => self::FLOAT_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'The number of virtual cpus.',
+            ],
+            'memory' => [
+                'type'        => self::INT_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'The container memory size in MiB.',
+            ],
+            'workdir' => [
+                'type'        => self::STRING_TYPE,
+                'location'    => self::JSON,
+                'sentAs'      => 'workdir',
+                'required'    => false,
+                'description' => 'The working directory for commands to run in.',
+            ],
+            'labels' => [
+                'type'        => self::OBJECT_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'Adds a map of labels to a container.',
+            ],
+            'environment' => [
+                'type'        => self::OBJECT_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'The environment variables to set in the container.',
+            ],
+            'restartPolicy' => [
+                'type'        => self::OBJECT_TYPE,
+                'location'    => self::JSON,
+                'sentAs'      => 'restart_policy',
+                'required'    => false,
+                'description' => 'Restart policy to apply when a container exits. It must contain a Name key and its allowed values are no, on-failure, always, unless-stopped. Optionally, it can contain a MaximumRetryCount key and its value is an integer.',
+                'properties'  => $this->restartPolicy(),
+            ],
+            'interactive' => [
+                'type'        => self::BOOL_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'Keep STDIN open even if not attached.',
+            ],
+            'tty' => [
+                'type'        => self::BOOL_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'Whether this container should allocate a TTY for itself.',
+            ],
+            'imageDriver' => [
+                'type'        => self::STRING_TYPE,
+                'location'    => self::JSON,
+                'sentAs'      => 'image_driver',
+                'required'    => false,
+                'description' => 'The image driver to use to pull container image. Allowed values are docker to pull the image from Docker Hub and glance to pull the image from Glance.',
+                'enum'        => ['docker', 'glance'],
+            ],
+            'securityGroups' => [
+                'type'        => self::STRING_TYPE,
+                'location'    => self::JSON,
+                'sentAs'      => 'security_groups',
+                'required'    => false,
+                'description' => 'Security groups to be added to the container.',
+            ],
+            'nets' => [
+                'type'        => self::ARRAY_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'A list of networks for the container.',
+            ],
+            'runtime' => [
+                'type'        => self::STRING_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'The container runtime tool to create container with. You can use the default runtime that is runc or any other runtime configured to use with Docker.',
+            ],
+            'hostname' => [
+                'type'        => self::STRING_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'The hostname of container.',
+            ],
+            'autoRemove' => [
+                'type'        => self::BOOL_TYPE,
+                'location'    => self::JSON,
+                'sentAs'      => 'auto_remove',
+                'required'    => false,
+                'description' => 'enable auto-removal of the container on daemon side when the container’s process exits.',
+            ],
+            'autoHeal' => [
+                'type'        => self::BOOL_TYPE,
+                'location'    => self::JSON,
+                'sentAs'      => 'auto_heal',
+                'required'    => false,
+                'description' => 'The flag of healing non-existent container in docker.',
+            ],
+            'availabilityZone' => [
+                'type'        => self::STRING_TYPE,
+                'location'    => self::JSON,
+                'sentAs'      => 'availability_zone',
+                'required'    => false,
+                'description' => 'The availability zone from which to run the container.',
+            ],
+            'hints' => [
+                'type'        => self::STRING_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'The dictionary of data to send to the scheduler.',
+            ],
+            'mounts' => [
+                'type'        => self::ARRAY_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'A list of dictionary data to specify how volumes are mounted into the container.',
+                'items'       => $this->mount(),
+            ],
+            'privileged' => [
+                'type'        => self::BOOL_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'Give extended privileges to the container.',
+            ],
+            'healthcheck' => [
+                'type'        => self::OBJECT_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'A dict of health check for the container.',
+                'properties'  => $this->healthcheck(),
+            ],
+            'exposedPorts' => [
+                'type'        => self::ARRAY_TYPE,
+                'location'    => self::JSON,
+                'sentAs'      => 'exposed_ports',
+                'required'    => false,
+                'description' => 'A list of dictionary data to specify how to expose container’s ports.',
+                'items'       => ['type' => self::STRING_TYPE],
+            ],
+            'host' => [
+                'type'        => self::STRING_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'The name of the host on which the container is to be created.',
+            ],
+            'entrypoint' => [
+                'type'        => self::ARRAY_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'The entrypoint which overwrites the default ENTRYPOINT of the image.',
+                'items'       => ['type' => self::STRING_TYPE],
+            ],
+        ];
+    }
+
+    public function restartPolicy(): array
+    {
+        return [
+            'name' => [
+                'type'        => self::STRING_TYPE,
+                'location'    => self::JSON,
+                'required'    => true,
+                'description' => 'The name of the restart policy.',
+                'enum'        => ['no', 'on-failure', 'always', 'unless-stopped'],
+            ],
+            'maximumRetryCount' => [
+                'type' => self::INT_TYPE,
+            ],
+        ];
+    }
+
+    public function mount(): array
+    {
+        return [
+            'type' => [
+                'type'        => self::STRING_TYPE,
+                'location'    => self::JSON,
+                'required'    => true,
+                'description' => 'The type of mount.',
+                'enum'        => ['bind', 'volume'],
+            ],
+            'source' => [
+                'type'        => self::STRING_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'The source of the mount.',
+            ],
+            'size' => [
+                'type'        => self::INT_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => "The size of the dynamic mount's volume.",
+            ],
+            'destination' => [
+                'type'        => self::STRING_TYPE,
+                'location'    => self::JSON,
+                'required'    => false,
+                'description' => 'The destination of the mount for the "bind" type.',
+            ],
+        ];
+    }
+
+    public function healthcheck(): array
+    {
+        return [
+            'cmd' => [
+                'type'        => self::STRING_TYPE,
+                'location'    => self::JSON,
+                'required'    => true,
+                'description' => 'The command to run to check the health of the container.',
+            ],
+            'interval' => [
+                'type'        => self::INT_TYPE,
+                'location'    => self::JSON,
+                'required'    => true,
+                'description' => 'The interval to check the health of the container.',
+            ],
+            'retries' => [
+                'type'        => self::INT_TYPE,
+                'location'    => self::JSON,
+                'required'    => true,
+                'description' => 'The number of retries to check the health of the container.',
+            ],
+            'timeout' => [
+                'type'        => self::INT_TYPE,
+                'location'    => self::JSON,
+                'required'    => true,
+                'description' => 'The timeout to check the health of the container.',
+            ],
+        ];
+    }
+
+    /**
+     * @param string|null $resource Not used
+     */
+    public function name(?string $resource = null): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'location'    => self::QUERY,
+            'required'    => false,
+            'description' => 'Filters the response by name.',
+        ];
+    }
+
+    public function image(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'location'    => self::QUERY,
+            'required'    => false,
+            'description' => 'Filters the response by image.',
+        ];
+    }
+
+    public function projectId(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'location'    => self::QUERY,
+            'sentAs'      => 'project_id',
+            'required'    => false,
+            'description' => 'Filters the response by the ID of the project.',
+        ];
+    }
+
+    public function userId(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'location'    => self::QUERY,
+            'sentAs'      => 'user_id',
+            'required'    => false,
+            'description' => 'Filters the response by user ID.',
+        ];
+    }
+
+    public function memory(): array
+    {
+        return [
+            'type'        => self::INT_TYPE,
+            'location'    => self::QUERY,
+            'required'    => false,
+            'description' => 'Filters the response by memory size in Mib.',
+        ];
+    }
+
+    public function host(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'location'    => self::QUERY,
+            'required'    => false,
+            'description' => 'Filters the response by a host name, as a string.',
+        ];
+    }
+
+    public function taskState(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'location'    => self::QUERY,
+            'sentAs'      => 'task_state',
+            'required'    => false,
+            'description' => 'Filters the response by task state.',
+        ];
+    }
+
+    public function status(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'location'    => self::QUERY,
+            'required'    => false,
+            'description' => 'Filters the response by the current state of the container.',
+        ];
+    }
+
+    public function autoRemove(): array
+    {
+        return [
+            'type'        => self::BOOL_TYPE,
+            'location'    => self::QUERY,
+            'sentAs'      => 'auto_remove',
+            'required'    => false,
+            'description' => 'Filters the response according to whether they are auto-removed on exiting.',
+        ];
+    }
+
+    public function signal(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'location'    => self::QUERY,
+            'required'    => false,
+            'description' => 'Sends a signal to the container.',
+        ];
+    }
+
+    public function since(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'location'    => self::QUERY,
+            'required'    => false,
+            'description' => 'Show logs since a given datetime or integer epoch (in seconds).',
+        ];
+    }
+
+    public function stdout(): array
+    {
+        return [
+            'type'        => self::BOOL_TYPE,
+            'location'    => self::QUERY,
+            'required'    => false,
+            'description' => 'Only stdout logs of container.',
+        ];
+    }
+
+    public function stderr(): array
+    {
+        return [
+            'type'        => self::BOOL_TYPE,
+            'location'    => self::QUERY,
+            'required'    => false,
+            'description' => 'Only stderr logs of container.',
+        ];
+    }
+
+    public function timestamps(): array
+    {
+        return [
+            'type'        => self::BOOL_TYPE,
+            'location'    => self::QUERY,
+            'required'    => false,
+            'description' => 'Show timestamps.',
+        ];
+    }
+
+    public function tail(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'location'    => self::QUERY,
+            'required'    => false,
+            'description' => 'Number of lines to show from the end of the logs.',
+        ];
+    }
+
+    public function ttyWidth(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'location'    => self::QUERY,
+            'required'    => true,
+            'description' => 'The tty width of a container.',
+        ];
+    }
+
+    public function ttyHeight(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'location'    => self::QUERY,
+            'required'    => true,
+            'description' => 'The tty height of a container.',
+        ];
+    }
+
+    public function repository(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'location'    => self::QUERY,
+            'required'    => true,
+            'description' => 'The repository of the container image.',
+        ];
+    }
+
+    public function tag(): array
+    {
+        return [
+            'type'        => self::STRING_TYPE,
+            'location'    => self::QUERY,
+            'required'    => true,
+            'description' => 'The tag of the container image.',
+        ];
+    }
+}

--- a/src/Containers/v1/Service.php
+++ b/src/Containers/v1/Service.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenStack\Containers\v1;
+
+use Generator;
+use OpenStack\Common\Service\AbstractService;
+use OpenStack\Containers\v1\Models\Container;
+use OpenStack\Containers\v1\Models\ContainerImage;
+
+/**
+ * @property Api $api
+ */
+class Service extends AbstractService
+{
+    /**
+     * Create a new container.
+     *
+     * @param array $options {@see Api::create}
+     */
+    public function createContainer(array $options): Container
+    {
+        return $this->model(Container::class)->create($options);
+    }
+
+    /**
+     * List containers.
+     *
+     * @param array         $options {@see Api::list}
+     * @param callable|null $mapFn   optional function to map over the results
+     *
+     * @return Generator<mixed, Container>
+     */
+    public function listContainers(array $options = [], ?callable $mapFn = null): Generator
+    {
+        return $this->model(Container::class)->enumerate($this->api->list(), $options, $mapFn);
+    }
+
+    /**
+     * Get a container.
+     *
+     * @param string $id the container ID or UUID
+     */
+    public function getContainer(string $id): Container
+    {
+        $container     = $this->model(Container::class);
+        $container->id = $id;
+
+        return $container;
+    }
+
+    /**
+     * Kill a container.
+     *
+     * @param string $id the container ID or UUID
+     */
+    public function killContainer(string $id): void
+    {
+        $this->getContainer($id)->kill();
+    }
+
+    /**
+     * Start a container.
+     *
+     * @param string $id the container ID or UUID
+     */
+    public function startContainer(string $id): void
+    {
+        $this->getContainer($id)->start();
+    }
+
+    /**
+     * Stop a container.
+     *
+     * @param string $id the container ID or UUID
+     */
+    public function stopContainer(string $id): void
+    {
+        $this->getContainer($id)->stop();
+    }
+
+    /**
+     * Reboot a container.
+     *
+     * @param string $id the container ID or UUID
+     */
+    public function rebootContainer(string $id): void
+    {
+        $this->getContainer($id)->reboot();
+    }
+
+    /**
+     * Rebuild a container.
+     *
+     * @param string $id the container ID or UUID
+     */
+    public function rebuildContainer(string $id): void
+    {
+        $this->getContainer($id)->rebuild();
+    }
+
+    /**
+     * Pause a container.
+     *
+     * @param string $id the container ID or UUID
+     */
+    public function pauseContainer(string $id): void
+    {
+        $this->getContainer($id)->pause();
+    }
+
+    /**
+     * Unpause a container.
+     *
+     * @param string $id the container ID or UUID
+     */
+    public function unpauseContainer(string $id): void
+    {
+        $this->getContainer($id)->unpause();
+    }
+
+    /**
+     * Get container logs.
+     *
+     * @param string $id      the container ID or UUID
+     * @param array  $options {@see Api::logs}
+     */
+    public function getContainerLogs(string $id, array $options = []): string
+    {
+        return $this->getContainer($id)->logs($options);
+    }
+
+    /**
+     * Attach to a container.
+     *
+     * @param string $id the container ID or UUID
+     *
+     * @return string TTY websocket URL
+     */
+    public function attachContainer(string $id): string
+    {
+        return $this->getContainer($id)->attach();
+    }
+
+    /**
+     * Resize tty of a container.
+     *
+     * @param string $id      the container ID or UUID
+     * @param array  $options {@see Api::resize}
+     */
+    public function resizeContainer(string $id, array $options = []): void
+    {
+        $this->getContainer($id)->resize($options);
+    }
+
+    /**
+     * Commit a container (make a snapshot into a new container image).
+     *
+     * @param string $id      the container ID or UUID
+     * @param array  $options {@see Api::commit}
+     *
+     * @return ContainerImage Container Image with UUID of a snapshot
+     */
+    public function commitContainer(string $id, array $options = []): ContainerImage
+    {
+        return $this->getContainer($id)->commit($options);
+    }
+}

--- a/src/OpenStack.php
+++ b/src/OpenStack.php
@@ -200,4 +200,14 @@ class OpenStack
 
         return $this->builder->createService('Metric\\v1\\Gnocchi', array_merge($defaults, $options));
     }
+
+    /**
+     * Creates a new Zun Containers service v1.
+     */
+    public function zunContainersV1(array $options = []): Containers\v1\Service
+    {
+        $defaults = ['catalogName' => 'zun', 'catalogType' => 'container'];
+
+        return $this->builder->createService('Containers\\v1', array_merge($defaults, $options));
+    }
 }

--- a/tests/unit/Compute/v2/Models/ServerTest.php
+++ b/tests/unit/Compute/v2/Models/ServerTest.php
@@ -334,7 +334,7 @@ class ServerTest extends TestCase
         $userData = ['name' => 'newImage', 'metadata' => ['foo' => 'bar']];
 
         $expectedJson = ['createImage' => $userData];
-        $this->mockRequest('POST', 'servers/serverId/action', new Response(202), $expectedJson);
+        $this->mockRequest('POST', 'servers/serverId/action', new Response(202, [], '{"image_id":""}'), $expectedJson);
 
         $this->server->createImage($userData);
     }

--- a/tests/unit/Containers/v1/Fixtures/container-commit.resp
+++ b/tests/unit/Containers/v1/Fixtures/container-commit.resp
@@ -1,0 +1,6 @@
+HTTP/1.1 202 Accepted
+Content-Type: application/json
+
+{
+    "uuid": "64281d85-e9a3-4c54-8d30-9ee72a596d8a"
+}

--- a/tests/unit/Containers/v1/Fixtures/container-get.resp
+++ b/tests/unit/Containers/v1/Fixtures/container-get.resp
@@ -1,0 +1,17 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "uuid": "container-uuid",
+    "name": "test-container",
+    "image": "ubuntu",
+    "status": "Running",
+    "task_state": null,
+    "user_id": "user-id",
+    "project_id": "project-id",
+    "cpu": 1,
+    "memory": 512,
+    "interactive": false,
+    "auto_remove": false,
+    "hostname": "test-host"
+}

--- a/tests/unit/Containers/v1/Fixtures/container-post.resp
+++ b/tests/unit/Containers/v1/Fixtures/container-post.resp
@@ -1,0 +1,7 @@
+HTTP/1.1 201 Created
+Content-Type: application/json
+
+{
+    "uuid": "new-uuid",
+    "name": "new-container"
+}

--- a/tests/unit/Containers/v1/Fixtures/containers-get.resp
+++ b/tests/unit/Containers/v1/Fixtures/containers-get.resp
@@ -1,0 +1,20 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+    "containers": [
+        {
+            "uuid": "uuid1",
+            "name": "container1",
+            "image": "ubuntu",
+            "status": "Running"
+        },
+        {
+            "uuid": "uuid2",
+            "name": "container2",
+            "image": "nginx",
+            "status": "Stopped"
+        }
+    ],
+    "next": null
+}

--- a/tests/unit/Containers/v1/Models/ContainerImageTest.php
+++ b/tests/unit/Containers/v1/Models/ContainerImageTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace OpenStack\Test\Containers\v1\Models;
+
+use OpenStack\Containers\v1\Api;
+use OpenStack\Containers\v1\Models\ContainerImage;
+use OpenStack\Test\TestCase;
+
+class ContainerImageTest extends TestCase
+{
+    private $containerImage;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rootFixturesDir = dirname(__DIR__);
+
+        $this->containerImage = new ContainerImage($this->client->reveal(), new Api());
+    }
+
+    public function test_it_populates_from_response()
+    {
+        $response = $this->getFixture('container-commit');
+
+        $this->containerImage->populateFromResponse($response);
+
+        self::assertEquals('64281d85-e9a3-4c54-8d30-9ee72a596d8a', $this->containerImage->uuid);
+    }
+}

--- a/tests/unit/Containers/v1/Models/ContainerTest.php
+++ b/tests/unit/Containers/v1/Models/ContainerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace OpenStack\Test\Containers\v1\Models;
+
+use GuzzleHttp\Psr7\Response;
+use OpenStack\Containers\v1\Api;
+use OpenStack\Containers\v1\Models\Container;
+use OpenStack\Containers\v1\Models\ContainerImage;
+use OpenStack\Test\TestCase;
+
+class ContainerTest extends TestCase
+{
+    private $container;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rootFixturesDir = dirname(__DIR__);
+
+        $this->container = new Container($this->client->reveal(), new Api());
+        $this->container->id = 'container-id';
+    }
+
+    public function test_it_deletes()
+    {
+        $this->mockRequest('DELETE', 'containers/container-id', new Response(204));
+        $this->container->delete();
+    }
+
+    public function test_it_starts()
+    {
+        $this->mockRequest('POST', 'containers/container-id/start', new Response(204));
+        $this->container->start();
+    }
+
+    public function test_it_stops()
+    {
+        $this->mockRequest('POST', 'containers/container-id/stop', new Response(204));
+        $this->container->stop();
+    }
+
+    public function test_it_reboots()
+    {
+        $this->mockRequest('POST', 'containers/container-id/reboot', new Response(204));
+        $this->container->reboot();
+    }
+
+    public function test_it_rebuilds()
+    {
+        $this->mockRequest('POST', 'containers/container-id/rebuild', new Response(204));
+        $this->container->rebuild();
+    }
+
+    public function test_it_pauses()
+    {
+        $this->mockRequest('POST', 'containers/container-id/pause', new Response(204));
+        $this->container->pause();
+    }
+
+    public function test_it_unpauses()
+    {
+        $this->mockRequest('POST', 'containers/container-id/unpause', new Response(204));
+        $this->container->unpause();
+    }
+
+    public function test_it_kills()
+    {
+        $this->mockRequest('POST', 'containers/container-id/kill', new Response(204));
+        $this->container->kill();
+    }
+
+    public function test_it_gets_logs()
+    {
+        $response = new Response(200, [], 'container logs');
+        $this->mockRequest('GET', 'containers/container-id/logs', $response);
+
+        $logs = $this->container->logs();
+
+        self::assertEquals('container logs', $logs);
+    }
+
+    public function test_it_attaches()
+    {
+        $response = new Response(200, [], 'wss://websocket-url');
+        $this->mockRequest('GET', 'containers/container-id/attach', $response);
+
+        $url = $this->container->attach();
+
+        self::assertEquals('wss://websocket-url', $url);
+    }
+
+    public function test_it_resizes()
+    {
+        $this->mockRequest('POST', ['path' => 'containers/container-id/resize', 'query' => ['width' => '80', 'height' => '24']], new Response(200));
+
+        $this->container->resize(['width' => '80', 'height' => '24']);
+    }
+
+    public function test_it_commits()
+    {
+        $this->mockRequest('POST', ['path' => 'containers/container-id/commit', 'query' => ['repository' => 'myrepo', 'tag' => 'latest']], 'container-commit');
+
+        $result = $this->container->commit(['repository' => 'myrepo', 'tag' => 'latest']);
+
+        self::assertInstanceOf(ContainerImage::class, $result);
+        self::assertEquals('64281d85-e9a3-4c54-8d30-9ee72a596d8a', $result->uuid);
+    }
+}

--- a/tests/unit/Containers/v1/ServiceTest.php
+++ b/tests/unit/Containers/v1/ServiceTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace OpenStack\Test\Containers\v1;
+
+use GuzzleHttp\Psr7\Response;
+use OpenStack\Containers\v1\Api;
+use OpenStack\Containers\v1\Models\Container;
+use OpenStack\Containers\v1\Models\ContainerImage;
+use OpenStack\Containers\v1\Service;
+use OpenStack\Test\TestCase;
+
+class ServiceTest extends TestCase
+{
+    /** @var Service */
+    private $service;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->rootFixturesDir = __DIR__;
+
+        $this->service = new Service($this->client->reveal(), new Api());
+    }
+
+    public function test_it_creates_a_container()
+    {
+        $opts = [
+            'name'  => 'new-container',
+            'image' => 'ubuntu',
+        ];
+
+        $this->mockRequest('POST', 'containers', 'container-post', $opts);
+
+        $container = $this->service->createContainer($opts);
+
+        self::assertEquals('new-uuid', $container->uuid);
+        self::assertEquals('new-container', $container->name);
+    }
+
+    public function test_it_lists_containers()
+    {
+        $this->mockRequest('GET', 'containers', 'containers-get');
+
+        $containers = $this->service->listContainers();
+
+        $count = 0;
+        foreach ($containers as $container) {
+            self::assertInstanceOf(Container::class, $container);
+            $count++;
+        }
+
+        self::assertEquals(2, $count);
+    }
+
+    public function test_it_gets_a_container()
+    {
+        $container = $this->service->getContainer('container-id');
+
+        self::assertInstanceOf(Container::class, $container);
+        self::assertEquals('container-id', $container->id);
+    }
+
+    public function test_it_kills_a_container()
+    {
+        $this->mockRequest('POST', 'containers/container-id/kill', new Response(204));
+
+        $this->service->killContainer('container-id');
+    }
+
+    public function test_it_starts_a_container()
+    {
+        $this->mockRequest('POST', 'containers/container-id/start', new Response(204));
+
+        $this->service->startContainer('container-id');
+    }
+
+    public function test_it_stops_a_container()
+    {
+        $this->mockRequest('POST', 'containers/container-id/stop', new Response(204));
+
+        $this->service->stopContainer('container-id');
+    }
+
+    public function test_it_reboots_a_container()
+    {
+        $this->mockRequest('POST', 'containers/container-id/reboot', new Response(204));
+
+        $this->service->rebootContainer('container-id');
+    }
+
+    public function test_it_rebuilds_a_container()
+    {
+        $this->mockRequest('POST', 'containers/container-id/rebuild', new Response(204));
+
+        $this->service->rebuildContainer('container-id');
+    }
+
+    public function test_it_pauses_a_container()
+    {
+        $this->mockRequest('POST', 'containers/container-id/pause', new Response(204));
+
+        $this->service->pauseContainer('container-id');
+    }
+
+    public function test_it_unpauses_a_container()
+    {
+        $this->mockRequest('POST', 'containers/container-id/unpause', new Response(204));
+
+        $this->service->unpauseContainer('container-id');
+    }
+
+    public function test_it_gets_container_logs()
+    {
+        $response = new Response(200, [], 'container logs');
+        $this->mockRequest('GET', 'containers/container-id/logs', $response);
+
+        $logs = $this->service->getContainerLogs('container-id');
+
+        self::assertEquals('container logs', $logs);
+    }
+
+    public function test_it_attaches_to_a_container()
+    {
+        $response = new Response(200, [], 'wss://websocket-url');
+        $this->mockRequest('GET', 'containers/container-id/attach', $response);
+
+        $url = $this->service->attachContainer('container-id');
+
+        self::assertEquals('wss://websocket-url', $url);
+    }
+
+    public function test_it_resizes_a_container()
+    {
+        $this->mockRequest('POST', ['path' => 'containers/container-id/resize', 'query' => ['width' => '80', 'height' => '24']], new Response(200));
+
+        $this->service->resizeContainer('container-id', ['width' => '80', 'height' => '24']);
+    }
+
+    public function test_it_commits_a_container()
+    {
+        $this->mockRequest('POST', ['path' => 'containers/container-id/commit', 'query' => ['repository' => 'myrepo', 'tag' => 'latest']], 'container-commit');
+
+        $result = $this->service->commitContainer('container-id', ['repository' => 'myrepo', 'tag' => 'latest']);
+
+        self::assertEquals('64281d85-e9a3-4c54-8d30-9ee72a596d8a', $result->uuid);
+    }
+}


### PR DESCRIPTION
### Pull Request Summary

This set of changes introduces support for the new **Zun (Containers v1)** service to the php-openstack library, along with several improvements to shared mechanisms and the development environment configuration.

### Summary
- Added full support for the **OpenStack Zun (Containers v1)** service, enabling container management.
- Introduced **Docker Compose** configuration for the development environment.
- Improved the resource iteration mechanism to prevent infinite loops during faulty pagination.
- Added support for **floating-point types** (`float`) in API parameter definitions.

### Changes

#### Infrastructure and Configuration
- Added `Dockerfile` and `docker-compose.yml` to allow running tests and PHP within a container.
- Updated `CONTRIBUTING.md` with instructions on using Docker for dependency installation.

#### Core / Common
- **AbstractApi**: Added property typing for `$params` to `AbstractParams`.
- **AbstractParams**: Added a new `FLOAT_TYPE` (`double`) constant, supporting floating-point parameters in API definitions.
- **Iterator**: Introduced a `sentMarkers` mechanism that prevents re-sending the same markers, protecting against infinite loops in case of incorrect server responses.

#### Containers Service (Zun) v1
- Implementation of the new service in `src/Containers/v1`:
    - **Api**: Endpoint definitions for container operations (list, create, get, delete, start, stop, reboot, rebuild, pause, unpause, kill, logs, attach, resize, commit).
    - **Models**: `Container` and `ContainerImage` models.
    - **Service**: Main service class with methods such as `createContainer`, `listContainers`, `getContainer`, and various action methods.
    - **Params**: Detailed definitions of JSON and Query parameters for all Zun operations.
- Registered the new service in the main `OpenStack` class via the `zunContainersV1()` method.

#### Tests and Fixes
- Added comprehensive unit tests for the new Zun service: `ServiceTest`, `ContainerTest`, `ContainerImageTest`.
- Added appropriate API response mocks (Fixtures) for containers.
- **Compute v2**: Minor fix in `ServerTest` regarding the response mock when creating an image.

### Verification
- Added new unit tests covering CRUD operations and container actions.
- Verified correct parameter mapping (including the new float types for CPU).
- All new tests in `tests/unit/Containers/v1` are passing successfully.